### PR TITLE
do not fail when a relation cannot be created

### DIFF
--- a/app/controllers/code_review_controller.rb
+++ b/app/controllers/code_review_controller.rb
@@ -401,6 +401,6 @@ class CodeReviewController < ApplicationController
     relation.relation_type = type
     relation.issue_from_id = review.issue.id
     relation.issue_to_id = issue.id
-    relation.save!
+    relation.save
   end
 end


### PR DESCRIPTION
This can easily happen e.g. if it would create a circular dependency, and in this case,
the user is left with a review he cannot save, without an error message. I think it is better to silently not create the relation in this case.