### PR TITLE
Add of missing "Priority" field on issue creation form

### DIFF
--- a/app/controllers/code_review_controller.rb
+++ b/app/controllers/code_review_controller.rb
@@ -17,7 +17,7 @@
 
 class CodeReviewController < ApplicationController
   unloadable
-  before_action :find_project, :authorize, :find_user, :find_setting, :find_repository
+  before_action :find_project, :authorize, :find_user, :find_setting, :find_repository, :find_priorities
 
   helper :sort
   include SortHelper
@@ -373,6 +373,10 @@ class CodeReviewController < ApplicationController
 
   def find_setting
     @setting = CodeReviewProjectSetting.find_or_create(@project)
+  end
+
+  def find_priorities
+    @priorities = IssuePriority.active
   end
 
   def get_parent_candidate(revision)

--- a/app/views/code_review/_new_form.html.erb
+++ b/app/views/code_review/_new_form.html.erb
@@ -66,6 +66,10 @@
         <input type="button" value="<%=h l(:general_text_Yes)%>" onclick="$('#review_parent_id').val(<%= @parent_candidate.id %>)"/>
       <% end %>
     </p>
+    <p>
+      <label><b><%=h l(:field_priority)%>:</b></label>
+      <%= select :issue, :priority_id, (@priorities.collect {|p| [p.name, p.id]}), :required => true %>
+    </p>
     <% @issue.custom_field_values.each do |value| %>
       <% next unless value.required? -%>
       <p><%= custom_field_tag_with_label :issue, value %></p>


### PR DESCRIPTION
When browsing source code files from the repository browser view, it is possible to create code review issues by clicking on the pencil icon of a given line.

When doing so, a modal popup appears with an issue creation form.

Unfortunately, this form could not be validated since the priority information (which is mandatory) could not be set.

This commit adds the missing "Priority" field to the issue creation form, so that it can be submitted without any blocking error.

