### PR TITLE
fix URI_decode_www_form_must_be_ASCII_only_string

### DIFF
--- a/app/controllers/code_review_controller.rb
+++ b/app/controllers/code_review_controller.rb
@@ -244,7 +244,7 @@ class CodeReviewController < ApplicationController
     if request.xhr? || !params[:update].blank?
       render partial: 'show'
     elsif target.path
-      path = URI.decode_www_form(target.path)
+      path = URI.decode_www_form(URI.encode_www_form_component(target.path))
       action_name = target.action_type
       rev_to = ''
       rev_to = '&rev_to=' + target.rev_to if target.rev_to


### PR DESCRIPTION
This pull request includes a single change to the `show` method in the `app/controllers/code_review_controller.rb` file. The change ensures that the `target.path` is properly encoded before decoding, preventing potential issues with special characters in the URL.

* [`app/controllers/code_review_controller.rb`](diffhunk://#diff-892299ef0308df758f80f87e5868694c246be97dbffff2e9568a49b15d805165L247-R247): Updated the `show` method to use `URI.encode_www_form_component` for encoding `target.path` before decoding it with `URI.decode_www_form`.Corrected errors when referring to Japanese file names I had a similar pull request, but it seemed to be using a deprecated method.